### PR TITLE
[FIX] ios 상태줄 black으로 변경

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     <!-- IOS -->
     <link rel="apple-touch-icon" sizes="192x192" href="/icons/icon-192x192.png">
     <link rel="apple-touch-icon" sizes="512x512" href="/icons/icon-512x512.png">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
   
     <!-- OG -->
     <meta property="og:title" content="문토미 - MOONTOMI">


### PR DESCRIPTION
#5 

ios  상태줄 반투명 -> black
반투명이 에러가 잦아서 black으로 롤백

추후에, 앱으로 말 때 조정하자.
아니면 작은 화면에서는 그냥 헤더를 없애버리는 것도 괜찮을듯?